### PR TITLE
Create dedicated health check endpoint

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,10 +4,11 @@ import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
 import { FriendsModule } from './friends/friends.module';
 import { GameModule } from './game/game.module';
+import { HealthModule } from './health/health.module';
 import { PrismaModule } from './prisma/prisma.module';
 
 @Module({
-  imports: [PrismaModule, GameModule, AuthModule, FriendsModule],
+  imports: [PrismaModule, GameModule, AuthModule, FriendsModule, HealthModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/game/game.controller.ts
+++ b/src/game/game.controller.ts
@@ -154,12 +154,6 @@ export class GameController {
     return this.gameService.getCardByCode(code);
   }
 
-  /** Health */
-  @Get('test')
-  test(): string {
-    return 'Online';
-  }
-
   /** Undo pick */
   @Post(':id/duel/unchoose-card')
   unchooseCard(@Param('id') id: string, @Body() body: { playerId: string }) {

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get } from '@nestjs/common';
+import { HealthService } from './health.service';
+import { HealthStatus } from './health.service';
+
+@Controller('health')
+export class HealthController {
+  constructor(private readonly healthService: HealthService) {}
+
+  @Get()
+  getHealth(): HealthStatus {
+    return this.healthService.getHealthStatus();
+  }
+}

--- a/src/health/health.module.ts
+++ b/src/health/health.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { HealthController } from './health.controller';
+import { HealthService } from './health.service';
+
+@Module({
+  controllers: [HealthController],
+  providers: [HealthService],
+})
+export class HealthModule {}

--- a/src/health/health.service.ts
+++ b/src/health/health.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+
+export interface HealthStatus {
+  status: 'ok';
+  timestamp: string;
+  uptimeInSeconds: number;
+}
+
+@Injectable()
+export class HealthService {
+  getHealthStatus(): HealthStatus {
+    return {
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+      uptimeInSeconds: Math.round(process.uptime()),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated health module with a controller and service that exposes GET /health
- register the health module with the application and remove the legacy /game/test endpoint from the game controller

## Testing
- not run (per instructions)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691681a96420832ca5ee2727443a723e)